### PR TITLE
Add Weight Goal Bot to TypeScript bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@
 
 - [BoomBot](https://github.com/MrBoomDeveloper/BoomBot) - A nice bot with bunch of useful things 
 
+- [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) - Bilingual group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements. [GitHub](https://github.com/IgorShadurin/weight-telegram-bot)
+
 ### ➤ Tools
 
 - [Ultroid](https://github.com/TeamUltroid/Ultroid) - Advanced Multi-Featured Telegram UserBot, Built in Python Using Telethon lib.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@
 
 - [BoomBot](https://github.com/MrBoomDeveloper/BoomBot) - A nice bot with bunch of useful things 
 
-- [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) - Bilingual group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements. [GitHub](https://github.com/IgorShadurin/weight-telegram-bot)
+- [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) - Group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements in English, Russian, and Chinese. [GitHub](https://github.com/IgorShadurin/weight-telegram-bot)
 
 ### ➤ Tools
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@
 
 - [BoomBot](https://github.com/MrBoomDeveloper/BoomBot) - A nice bot with bunch of useful things 
 
-- [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) - Group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements in English, Russian, and Chinese. [GitHub](https://github.com/IgorShadurin/weight-telegram-bot)
+- [@my_weight_goal_bot](https://t.me/my_weight_goal_bot) - Group bot for photo-backed weekly weight goals, charts, reminders, 53 achievements, and nine natural localizations. [Apache-2.0 source](https://github.com/IgorShadurin/weight-telegram-bot)
 
 ### ➤ Tools
 


### PR DESCRIPTION
## Summary

Adds [Weight Goal Bot](https://t.me/my_weight_goal_bot) ([source](https://github.com/IgorShadurin/weight-telegram-bot)) to the TypeScript open-source bot section.

I maintain this Apache-2.0-licensed Telegram group bot. Its complete interface is naturally adapted for English, Russian, Chinese, Spanish, Portuguese, German, French, Japanese, and Indonesian; it uses photo-backed weigh-ins and provides weekly checkpoints, progress charts, reminders, and 53 achievements.

## Verification

- [x] The [live bot](https://t.me/my_weight_goal_bot) link resolves.
- [x] The [source repository](https://github.com/IgorShadurin/weight-telegram-bot) is public and licensed under Apache-2.0.
- [x] I searched this repository for an existing duplicate.
- [x] This change follows the existing live-bot, description, and GitHub-link format.